### PR TITLE
feat(Admin): Add avatar preview to testimonial edit form

### DIFF
--- a/src/Resources/config/resources.yaml
+++ b/src/Resources/config/resources.yaml
@@ -6,6 +6,8 @@ sylius_resource:
                 model: Softylines\SyliusTestimonialPlugin\Entity\Testimonial
                 repository: Softylines\SyliusTestimonialPlugin\Repository\TestimonialRepository
                 form: Softylines\SyliusTestimonialPlugin\Form\Type\TestimonialType
+            templates:
+                _form: "@SoftylinesSyliusTestimonialPlugin/Admin/Testimonial/_form.html.twig"
                 
 sylius_ui:
     events:

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -16,3 +16,4 @@ softylines_sylius_testimonial:
         no_testimonials: No testimonials available at the moment.
         view_all_testimonials: View all testimonials
         avatar_validation: Image must be JPG or PNG format and not exceed 2MB.
+        current_avatar: Current Avatar

--- a/src/Resources/views/Admin/Testimonial/_form.html.twig
+++ b/src/Resources/views/Admin/Testimonial/_form.html.twig
@@ -1,0 +1,20 @@
+{{ form_errors(form) }}
+
+<div class="ui segment">
+    <h4 class="ui dividing header">{{ 'sylius.ui.details'|trans }}</h4>
+    {{ form_row(form.name) }}
+    {{ form_row(form.content) }}
+    {{ form_row(form.enabled) }}
+
+    {# Avatar Preview and File Upload #}
+    {% if form.vars.data.avatar is not null and form.vars.data.avatar is not empty %}
+        <div class="field">
+            <label>{{ 'softylines_sylius_testimonial.ui.current_avatar'|trans }}</label>
+            <img src="{{ asset('media/testimonial/avatar/' ~ form.vars.data.avatar) }}" alt="{{ 'softylines_sylius_testimonial.ui.avatar'|trans }}" style="max-width: 150px; max-height: 150px; margin-bottom: 10px;" />
+        </div>
+    {% endif %}
+    {{ form_row(form.avatarFile) }}
+</div>
+
+{# Add any other sections or fields if necessary, like translations if supported #}
+{# {{ form_rest(form) }} #}


### PR DESCRIPTION
- Configured the testimonial resource to use a custom admin form template.
- Created `_form.html.twig` for testimonials to include a preview of the current avatar image if one exists.
- Added a translation for the "Current Avatar" label.

This resolves the issue where the avatar was not visible on the edit screen.

Further investigation notes:
- The "active is always true" issue: The plugin's handling of the 'enabled' field via `ToggleableTrait` and `CheckboxType` appears standard. I couldn't identify the root cause within this plugin's codebase; it may be environmental or related to your specific Sylius version/configuration.
- The "Created At not listed" issue: The plugin correctly configures the `createdAt` field for display in the admin grid using `TimestampableTrait` and grid YAML configuration. If it's not visible, the causes are likely external (caching, template overrides).