### PR TITLE
fix(Admin): Correct testimonial template configuration syntax

### DIFF
--- a/src/Resources/config/resources.yaml
+++ b/src/Resources/config/resources.yaml
@@ -6,8 +6,7 @@ sylius_resource:
                 model: Softylines\SyliusTestimonialPlugin\Entity\Testimonial
                 repository: Softylines\SyliusTestimonialPlugin\Repository\TestimonialRepository
                 form: Softylines\SyliusTestimonialPlugin\Form\Type\TestimonialType
-            templates:
-                _form: "@SoftylinesSyliusTestimonialPlugin/Admin/Testimonial/_form.html.twig"
+            templates: SoftylinesSyliusTestimonialPlugin:Admin/Testimonial
                 
 sylius_ui:
     events:


### PR DESCRIPTION
Changed the Sylius resource configuration for testimonial templates in `resources.yaml` from a map to a scalar string. This resolves a YAML parsing error where an array was provided but a scalar (template namespace) was expected.

The `templates` key now correctly points to the namespace `SoftylinesSyliusTestimonialPlugin:Admin/Testimonial`, allowing Sylius to locate custom CRUD templates like `_form.html.twig` within the plugin's `Resources/views/Admin/Testimonial/` directory.